### PR TITLE
conf(symfony): deprecated Bundle

### DIFF
--- a/src/RestPaginateurBundle.php
+++ b/src/RestPaginateurBundle.php
@@ -4,11 +4,13 @@ namespace RestPaginateur;
 
 use RestPaginateur\DependencyInjection\RestPaginateurExtension;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 final class RestPaginateurBundle extends Bundle
 {
-    public function getContainerExtension()
+    public function getContainerExtension(): ?ExtensionInterface
     {
         return new RestPaginateurExtension();
     }
 }
+


### PR DESCRIPTION
User Deprecated: Method "Symfony\Component\HttpKernel\Bundle\Bundle::getContainerExtension()" might add "?ExtensionInterface" as a native return type declaration in the future. Do the same in child class "RestPaginateur\RestPaginateurBundle" now to avoid errors or add an explicit @return annotation to suppress this message